### PR TITLE
Increase sequence table performance.

### DIFF
--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -85,7 +85,7 @@ module ActiveRecord::Turntable::Migration
 
   module SchemaStatementsExt
     def create_sequence_for(table_name, options = { })
-      options = options.reverse_merge(:options => "ENGINE=MyISAM").merge(:id => false)
+      options = options.merge(:id => false)
 
       # TODO: pkname should be pulled from table definitions
       pkname = "id"

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -85,11 +85,14 @@ module ActiveRecord::Turntable::Migration
 
   module SchemaStatementsExt
     def create_sequence_for(table_name, options = { })
+      options = options.reverse_merge(:options => "ENGINE=MyISAM").merge(:id => false)
+
       # TODO: pkname should be pulled from table definitions
       pkname = "id"
       sequence_table_name = ActiveRecord::Turntable::Sequencer.sequence_name(table_name, "id")
-      create_table(sequence_table_name, options)
-      execute "ALTER TABLE #{quote_table_name(sequence_table_name)} MODIFY id bigint(20) DEFAULT NULL auto_increment NOT NULL;"
+      create_table(sequence_table_name, options) do |t|
+        t.integer :id, :limit => 8
+      end
       execute "INSERT INTO #{quote_table_name(sequence_table_name)} (`id`) VALUES (0)"
     end
 

--- a/lib/active_record/turntable/sequencer/mysql.rb
+++ b/lib/active_record/turntable/sequencer/mysql.rb
@@ -13,9 +13,7 @@ module ActiveRecord::Turntable
 
       def next_sequence_value(sequence_name)
         conn = @klass.connection.seq.connection
-        conn.execute "BEGIN"
         conn.execute "UPDATE #{@klass.connection.quote_table_name(sequence_name)} SET id=LAST_INSERT_ID(id+1)"
-        conn.execute "COMMIT"
         res = conn.execute("SELECT LAST_INSERT_ID()")
         new_id = res.first.first.to_i
         raise SequenceNotFoundError if new_id.zero?

--- a/lib/active_record/turntable/sequencer/mysql.rb
+++ b/lib/active_record/turntable/sequencer/mysql.rb
@@ -21,7 +21,9 @@ module ActiveRecord::Turntable
       end
 
       def current_sequence_value(sequence_name)
-        res = @klass.connection.seq.connection.execute("SELECT id FROM #{@klass.connection.quote_table_name(sequence_name)} LIMIT 1")
+        conn = @klass.connection.seq.connection
+        conn.execute "UPDATE #{@klass.connection.quote_table_name(sequence_name)} SET id=LAST_INSERT_ID(id)"
+        res = conn.execute("SELECT LAST_INSERT_ID()")
         current_id = res.first.first.to_i
         return current_id
       end


### PR DESCRIPTION
padrino対応ブランチにも sequence table高速化差分をいれる
