### PR TITLE
Padrino.env の削除

### DIFF
--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Turntable
         protected
 
         if ActiveRecord::VERSION::STRING < '3.1'
-          def log_without_newrelic_instrumentation(sql, name)
+          def log(sql, name)
             name ||= "SQL"
             @instrumenter.instrument("sql.active_record",
                                      :sql => sql, :name => name, :connection_id => object_id,
@@ -20,7 +20,7 @@ module ActiveRecord::Turntable
             raise translate_exception(e, message)
           end
         else
-          def log_without_newrelic_instrumentation(sql, name = "SQL", binds = [])
+          def log(sql, name = "SQL", binds = [])
             @instrumenter.instrument(
                                      "sql.active_record",
                                      :sql           => sql,
@@ -36,8 +36,9 @@ module ActiveRecord::Turntable
             raise exception
           end
         end
-        if not defined?(::NewRelic)
-          alias_method :log, :log_without_newrelic_instrumentation
+        if defined?(::NewRelic)
+          alias_method :log_without_newrelic_instrumentation, :log
+          alias_method :log, :log_with_newrelic_instrumentation
         end
       end
 

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -37,8 +37,8 @@ module ActiveRecord::Turntable
           end
         end
 
-        alias_method_chain :log, :newrelic_instrumentation if defined?(::NewRelic)
-
+        alias_method_chain :log, :newrelic_instrumentation if method_defined?(:log_with_newrelic_instrumentation)
+        
       end
 
       def turntable_shard_name=(name)

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -36,10 +36,9 @@ module ActiveRecord::Turntable
             raise exception
           end
         end
-        if defined?(::NewRelic)
-          alias_method :log_without_newrelic_instrumentation, :log
-          alias_method :log, :log_with_newrelic_instrumentation
-        end
+
+        alias_method_chain :log, :newrelic_instrumentation if defined?(::NewRelic)
+
       end
 
       def turntable_shard_name=(name)

--- a/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
+++ b/lib/active_record/turntable/active_record_ext/abstract_adapter.rb
@@ -7,7 +7,7 @@ module ActiveRecord::Turntable
         protected
 
         if ActiveRecord::VERSION::STRING < '3.1'
-          def log(sql, name)
+          def log_without_newrelic_instrumentation(sql, name)
             name ||= "SQL"
             @instrumenter.instrument("sql.active_record",
                                      :sql => sql, :name => name, :connection_id => object_id,
@@ -20,7 +20,7 @@ module ActiveRecord::Turntable
             raise translate_exception(e, message)
           end
         else
-          def log(sql, name = "SQL", binds = [])
+          def log_without_newrelic_instrumentation(sql, name = "SQL", binds = [])
             @instrumenter.instrument(
                                      "sql.active_record",
                                      :sql           => sql,
@@ -35,6 +35,9 @@ module ActiveRecord::Turntable
             exception.set_backtrace e.backtrace
             raise exception
           end
+        end
+        if not defined?(::NewRelic)
+          alias_method :log, :log_without_newrelic_instrumentation
         end
       end
 

--- a/lib/active_record/turntable/active_record_ext/log_subscriber.rb
+++ b/lib/active_record/turntable/active_record_ext/log_subscriber.rb
@@ -35,7 +35,15 @@ module ActiveRecord::Turntable
             return if 'SCHEMA' == payload[:name]
 
             name    = '%s (%.1fms)' % [payload[:name], event.duration]
-            shard = '[Shard: %s]' % (event.payload[:turntable_shard_name] ? event.payload[:turntable_shard_name] : nil)
+
+            connection = if event.payload[:turntable_shard_name]
+                           '[Shard: %s]' % event.payload[:turntable_shard_name]
+                         elsif event.payload[:connection_name]
+                           '[%s]' % event.payload[:connection_name]
+                         else
+                           '[unknown]'
+                         end
+
             sql     = payload[:sql].squeeze(' ')
             binds   = nil
 
@@ -47,18 +55,17 @@ module ActiveRecord::Turntable
 
             if odd?
               name = color(name, ActiveRecord::LogSubscriber::CYAN, true)
-              shard = color(shard, ActiveRecord::LogSubscriber::CYAN, true)
+              connection = color(connection, ActiveRecord::LogSubscriber::CYAN, true)
               sql  = color(sql, nil, true)
             else
               name = color(name, ActiveRecord::LogSubscriber::MAGENTA, true)
-              shard = color(shard, ActiveRecord::LogSubscriber::MAGENTA, true)
+              connection = color(connection, ActiveRecord::LogSubscriber::MAGENTA, true)
             end
 
-            debug "  #{name} #{shard} #{sql}#{binds}"
+            debug "  #{name} #{connection} #{sql}#{binds}"
           end
         end
       end
     end
   end
 end
-

--- a/lib/active_record/turntable/connection_proxy.rb
+++ b/lib/active_record/turntable/connection_proxy.rb
@@ -237,7 +237,7 @@ module ActiveRecord::Turntable
     end
 
     def spec
-      @spec ||= master.connection_pool.spec
+      @spec ||= shards.values.first.connection_pool.spec
     end
   end
 end

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -65,7 +65,7 @@ module ActiveRecord::Turntable::Migration
     config = ActiveRecord::Base.configurations
     @@current_shard = nil
     shards = (self.class.target_shards||=[]).flatten.uniq.compact
-    if self.class.target_shards.blank?
+    if self.class.target_shards.blank? || self.class.target_seqs.blank?
       return migrate_without_turntable(direction)
     end
     shards_conf = shards.map do |shard|

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -64,10 +64,11 @@ module ActiveRecord::Turntable::Migration
   def migrate_with_turntable(direction)
     config = ActiveRecord::Base.configurations
     @@current_shard = nil
-    shards = (self.class.target_shards||=[]).flatten.uniq.compact
     if self.class.target_shards.blank? || self.class.target_seqs.blank?
       return migrate_without_turntable(direction)
     end
+
+    shards = (self.class.target_shards||=[]).flatten.uniq.compact
     shards_conf = shards.map do |shard|
       config[ActiveRecord::Turntable::RackupFramework.env||"development"]["shards"][shard]
     end

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -39,28 +39,17 @@ module ActiveRecord::Turntable::Migration
   module ShardDefinition
     def clusters(*cluster_names)
       config = ActiveRecord::Base.turntable_config
-      (self.target_shards ||= []) <<
-        if cluster_names.first == :all
-          config['clusters'].map do |name, cluster_conf|
-            cluster_conf["shards"].map {|shard| shard["connection"]}
-          end
-        else
-          cluster_names.map do |cluster_name|
-            config['clusters'][cluster_name]["shards"].map do |shard|
-              shard["connection"]
-            end
-          end
+      if cluster_names.first == :all
+        config['clusters'].map do |name, cluster_conf|
+          (self.target_shards ||= []) << cluster_conf["shards"].map { |shard| shard["connection"] }
+          (self.target_seqs ||= []) << cluster_conf["seq"]["connection"]
         end
-      (self.target_seqs ||= []) <<
-        if cluster_names.first == :all
-          config['clusters'].map do |name, cluster_conf|
-            cluster_conf["seq"]["connection"]
-          end
-        else
-          cluster_names.map do |cluster_name|
-            config['clusters'][cluster_name]["seq"]["connection"]
-          end
+      else
+        cluster_names.map do |cluster_name|
+          (self.target_shards ||= []) << config['clusters'][cluster_name]["shards"].map { |shard| shard["connection"] }
+          (self.target_seqs ||= []) << config['clusters'][cluster_name]["seq"]["connection"]
         end
+      end
     end
 
     def shards(*connection_names)

--- a/lib/active_record/turntable/migration.rb
+++ b/lib/active_record/turntable/migration.rb
@@ -65,14 +65,14 @@ module ActiveRecord::Turntable::Migration
     config = ActiveRecord::Base.configurations
     @@current_shard = nil
     shards = (self.class.target_shards||=[]).flatten.uniq.compact
-    seqs = (self.class.target_seqs||=[]).flatten.uniq.compact
-    if self.class.target_shards.blank? || self.class.target_seqs.blank?
+    if self.class.target_shards.blank?
       return migrate_without_turntable(direction)
     end
-
     shards_conf = shards.map do |shard|
       config[ActiveRecord::Turntable::RackupFramework.env||"development"]["shards"][shard]
     end
+
+    seqs = (self.class.target_seqs||=[]).flatten.uniq.compact
     seqs_conf = config[ActiveRecord::Turntable::RackupFramework.env||"development"]["seq"].select { |key, val| seqs.include?(key) }
     shards_conf += seqs_conf.values
 

--- a/lib/active_record/turntable/sequencer/mysql.rb
+++ b/lib/active_record/turntable/sequencer/mysql.rb
@@ -11,9 +11,10 @@ module ActiveRecord::Turntable
         @options = options
       end
 
-      def next_sequence_value(sequence_name)
+      # mysql だけ offset を指定できるようにします
+      def next_sequence_value(sequence_name, offset = 1)
         conn = @klass.connection.seq.connection
-        conn.execute "UPDATE #{@klass.connection.quote_table_name(sequence_name)} SET id=LAST_INSERT_ID(id+1)"
+        conn.execute "UPDATE #{@klass.connection.quote_table_name(sequence_name)} SET id=LAST_INSERT_ID(id+#{offset})"
         res = conn.execute("SELECT LAST_INSERT_ID()")
         new_id = res.first.first.to_i
         raise SequenceNotFoundError if new_id.zero?


### PR DESCRIPTION
`ENV["RACK_ENV"]`を読むようにした
`Padrino.env` は symbolを返すが文字列と比較したりしていたので文字列を返すように変えましたが、気づいていないだけでsymbolで返す必要があるなら教えていただきたいです:pray:

ref: https://github.com/monsterstrike/server/issues/20555